### PR TITLE
Get a C-level backtrace from pytest when tests fail

### DIFF
--- a/.github/workflows/pydevd-tests-python.yml
+++ b/.github/workflows/pydevd-tests-python.yml
@@ -118,5 +118,5 @@ jobs:
         PYTHONPATH: .
         PYDEVD_USE_CYTHON: ${{matrix.PYDEVD_USE_CYTHON }}
       run: |
-        python -m pytest -n auto -rfE
+        gdb -return-child-result -batch -ex r -ex bt --args python -m pytest -n auto -rfE
 


### PR DESCRIPTION
This is a trick that used to exist in matplotlib and is pretty handy to get more details when something fails.